### PR TITLE
Fix android.view.WindowManager$BadTokenException crashes

### DIFF
--- a/src/android/RemoteInjectionPlugin.java
+++ b/src/android/RemoteInjectionPlugin.java
@@ -2,7 +2,6 @@ package com.truckmovers.cordova;
 
 import android.app.Activity;
 import android.app.AlertDialog;
-import android.content.DialogInterface;
 import android.content.res.AssetManager;
 import android.util.Base64;
 
@@ -17,6 +16,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.lang.ref.WeakReference;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -31,16 +31,16 @@ public class RemoteInjectionPlugin extends CordovaPlugin {
 
     // List of files to inject before injecting Cordova.
     private final ArrayList<String> preInjectionFileNames = new ArrayList<String>();
-    private int promptInterval;  // Delay before prompting user to retry in seconds
 
     private RequestLifecycle lifecycle;
 
     protected void pluginInitialize() {
         String pref = webView.getPreferences().getString("CRIInjectFirstFiles", "");
-        for (String path: pref.split(",")) {
+        for (String path : pref.split(",")) {
             preInjectionFileNames.add(path.trim());
         }
-        promptInterval = webView.getPreferences().getInteger("CRIPageLoadPromptInterval", 10);
+        // Delay before prompting user to retry in seconds
+        int promptInterval = webView.getPreferences().getInteger("CRIPageLoadPromptInterval", 1);
 
         final Activity activity = super.cordova.getActivity();
         final CordovaWebViewEngine engine = super.webView.getEngine();
@@ -114,7 +114,7 @@ public class RemoteInjectionPlugin extends CordovaPlugin {
 
     private void injectCordova() {
         List<String> jsPaths = new ArrayList<String>();
-        for (String path: preInjectionFileNames) {
+        for (String path : preInjectionFileNames) {
             jsPaths.add(path);
         }
 
@@ -134,7 +134,7 @@ public class RemoteInjectionPlugin extends CordovaPlugin {
         // (https://developer.mozilla.org/en-US/docs/Web/HTTP/data_URIs).  The script tag
         // is appended to the DOM and executed via a javascript URL (e.g. javascript:doJsStuff()).
         StringBuilder jsToInject = new StringBuilder();
-        for (String path: jsPaths) {
+        for (String path : jsPaths) {
             jsToInject.append(readFile(cordova.getActivity().getResources().getAssets(), path));
         }
         String jsUrl = "javascript:var script = document.createElement('script');";
@@ -178,14 +178,14 @@ public class RemoteInjectionPlugin extends CordovaPlugin {
      * Searches the provided path for javascript files recursively.
      *
      * @param assets
-     * @param path start path
+     * @param path   start path
      * @return found JS files
      */
-    private List<String> jsPathsToInject(AssetManager assets, String path){
+    private List<String> jsPathsToInject(AssetManager assets, String path) {
         List jsPaths = new ArrayList<String>();
 
         try {
-            for (String filePath: assets.list(path)) {
+            for (String filePath : assets.list(path)) {
                 String fullPath = path + File.separator + filePath;
 
                 if (fullPath.endsWith(".js")) {
@@ -205,13 +205,13 @@ public class RemoteInjectionPlugin extends CordovaPlugin {
     }
 
     private static class RequestLifecycle {
-        private final Activity activity;
+        private final WeakReference<Activity> activityRef;
         private final CordovaWebViewEngine engine;
         private UserPromptTask task;
         private final int promptInterval;
 
         RequestLifecycle(Activity activity, CordovaWebViewEngine engine, int promptInterval) {
-            this.activity = activity;
+            this.activityRef = new WeakReference<>(activity);
             this.engine = engine;
             this.promptInterval = promptInterval;
         }
@@ -240,8 +240,8 @@ public class RemoteInjectionPlugin extends CordovaPlugin {
                 task.cancel();
             }
 
-            if (promptInterval > 0 ) {
-                task = new UserPromptTask(this, activity, engine, url);
+            if (promptInterval > 0 && activityRef.get() != null && !activityRef.get().isFinishing()) {
+                task = new UserPromptTask(this, activityRef.get(), engine, url);
                 new Timer().schedule(task, promptInterval * 1000);
             }
         }
@@ -252,7 +252,7 @@ public class RemoteInjectionPlugin extends CordovaPlugin {
      */
     static class UserPromptTask extends TimerTask {
         private final RequestLifecycle lifecycle;
-        private final Activity activity;
+        private final WeakReference<Activity> activityRef;
         private final CordovaWebViewEngine engine;
         final String url;
 
@@ -260,7 +260,7 @@ public class RemoteInjectionPlugin extends CordovaPlugin {
 
         UserPromptTask(RequestLifecycle lifecycle, Activity activity, CordovaWebViewEngine engine, String url) {
             this.lifecycle = lifecycle;
-            this.activity = activity;
+            this.activityRef = new WeakReference<>(activity);
             this.engine = engine;
             this.url = url;
         }
@@ -282,35 +282,18 @@ public class RemoteInjectionPlugin extends CordovaPlugin {
 
         @Override
         public void run() {
-            if (lifecycle.isLoading()) {
+            if (lifecycle.isLoading() && activityRef.get() != null && !activityRef.get().isFinishing()) {
                 // Prompts the user giving them the choice to wait on the current request or retry.
-                lifecycle.activity.runOnUiThread(new Runnable() {
-                    @Override
-                    public void run() {
-                        AlertDialog.Builder builder = new AlertDialog.Builder(activity);
-                        builder.setMessage("The server is taking longer than expected to respond.")
-                                .setOnDismissListener(new DialogInterface.OnDismissListener() {
-                                    @Override
-                                    public void onDismiss(DialogInterface dialog) {
-                                        UserPromptTask.this.cleanup();
-                                    }
-                                })
-                                .setPositiveButton("Retry", new DialogInterface.OnClickListener() {
-                                    @Override
-                                    public void onClick(DialogInterface dialog, int id) {
-                                        // Obviously only works for GETs but good enough.
-                                        engine.loadUrl(engine.getUrl(), false);
-                                    }
-                                })
-                                .setNegativeButton("Wait", new DialogInterface.OnClickListener() {
-                                    @Override
-                                    public void onClick(DialogInterface dialog, int id) {
-                                        lifecycle.startTask(url);
-                                    }
-                                });
-                        AlertDialog dialog = UserPromptTask.this.alertDialog = builder.create();
-                        dialog.show();
-                    }
+                activityRef.get().runOnUiThread(() -> {
+                    AlertDialog.Builder builder = new AlertDialog.Builder(activityRef.get());
+                    builder.setMessage("The server is taking longer than expected to respond.")
+                            .setPositiveButton("Retry", (dialog, id) -> {
+                                // Obviously only works for GETs but good enough.
+                                engine.loadUrl(engine.getUrl(), false);
+                            })
+                            .setNegativeButton("Wait", (dialog, id) -> lifecycle.startTask(url));
+                    alertDialog = builder.create();
+                    alertDialog.show();
                 });
             } else {
                 lifecycle.stopTask();

--- a/src/android/RemoteInjectionPlugin.java
+++ b/src/android/RemoteInjectionPlugin.java
@@ -40,7 +40,7 @@ public class RemoteInjectionPlugin extends CordovaPlugin {
             preInjectionFileNames.add(path.trim());
         }
         // Delay before prompting user to retry in seconds
-        int promptInterval = webView.getPreferences().getInteger("CRIPageLoadPromptInterval", 1);
+        int promptInterval = webView.getPreferences().getInteger("CRIPageLoadPromptInterval", 10);
 
         final Activity activity = super.cordova.getActivity();
         final CordovaWebViewEngine engine = super.webView.getEngine();


### PR DESCRIPTION
Connected issue #31

The fix consists of checking whether the host activity, where the dialog is about to be shown, is still running and only proceed if it is, hence avoiding the crash from happening.